### PR TITLE
identation issue

### DIFF
--- a/Neutron/__init__.py
+++ b/Neutron/__init__.py
@@ -120,7 +120,7 @@ class Window:
             else:
                 content = str(open(file, "r").read())
 
-                soup_src = content
+            soup_src = content
 
         elif html:
             soup_src = html


### PR DESCRIPTION
soup_src = content inside if file block at Class Window's display method was misindented.

So, when users tried to display a window through html file from an exe bundle, soup_src wasn't assigned at all, and then, an UnboundLocalError is raised as it is:

File "Neutron\__init__.py", line 128, in display
UnboundLocalError: local variable 'soup_src' referenced before assignment

so, bringing soup_src a tabulation (4 spaces) back corrects this issue